### PR TITLE
Allow parens rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,7 @@ module.exports = {
     "react-hooks"
   ],
   rules: {
+    "arrow-parens": "warn",
     "react/display-name": "off",
     "react/prop-types": "off",
     "react/jsx-boolean-value": "off",


### PR DESCRIPTION
Prettier that we use eforces parens around single params. Eslint does… not. This will make it a warning that can be fixed with eslint --fix